### PR TITLE
Updated to Python 3.8.5: Now using venv with requirements.txt listed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+click==7.1.2
+Flask==1.1.2
+itsdangerous==1.1.0
+Jinja2==2.11.2
+MarkupSafe==1.1.1
+Werkzeug==1.0.1

--- a/tests/CWC_Test.py
+++ b/tests/CWC_Test.py
@@ -1,5 +1,6 @@
 import os
 import webbrowser
+import subprocess
 from threading import Thread
 
 # Open CWC new incognito window (ensures fresh load)
@@ -10,10 +11,11 @@ def chrome():
 
 # Open localhost server running CWC website
 def localhost():
-    os.system('python ../main.py')
+    python_venv = os.path.abspath('../venv/Scripts/python.exe')
+    CWC_main = os.path.abspath('../main.py')
+    subprocess.Popen([python_venv, CWC_main])
 
 # Rub both of these simultaneously:
-
 if __name__ == '__main__':
     Thread(target=localhost).start()
     Thread(target=chrome).start()

--- a/tests/debug.log
+++ b/tests/debug.log
@@ -1,1 +1,0 @@
-[0814/152325.106:ERROR:file_io.cc(89)] ReadExactly: expected 36, observed 0


### PR DESCRIPTION
Wanted to make sure everything works with a clean version of python. So 
anyone who downloads this repository with the listed requirements in a 
venv /should/ be able to run and test this website in a local server 
using "tests/CWC_test.py"